### PR TITLE
Minor fixes to validations and route definitions

### DIFF
--- a/src/interfaces/issn-registry/requests.js
+++ b/src/interfaces/issn-registry/requests.js
@@ -163,10 +163,6 @@ export default function () {
     const result = await issnFormModel.findByPk(id, {
       include: [
         {
-          association: 'publicationIssn',
-          attributes: ['id', 'title', 'subtitle', 'issn', 'language', 'medium', 'status', 'created', 'createdBy', 'modified', 'modifiedBy']
-        },
-        {
           association: 'publisherIssn',
           attributes: ['id', 'officialName']
         }
@@ -198,7 +194,7 @@ export default function () {
       const issnRequest = await issnFormModelInterface.read(id, t);
 
       // Status may be set only to either rejected or not_handled through GUI
-      // Status of not_notified is automatically when all form publications have ISSN
+      // Status of NOT_NOTIFIED is automatically set when last of form publications is given ISSN
       // Status of completed is automatically set when message is sent after all publications have ISSN
       /* Restriction regarding changing status manually has been lifted
       if (doc.status) {
@@ -223,7 +219,7 @@ export default function () {
       /* eslint-enable functional/immutable-data */
 
       // Save to db
-      const result = await issnRequest.update(dbDoc, {transaction: t});
+      await issnRequest.update(dbDoc, {transaction: t});
 
       // Update status of publications associated to form to NO_ISSN_GRANTED if form status
       // was changed to REJECTED
@@ -252,7 +248,7 @@ export default function () {
 
       // Verify all publications where updated
       await t.commit();
-      return result.toJSON();
+      return read(id);
     } catch (err) {
       await t.rollback();
       throw err;

--- a/src/routes/isbn-registry/publisher-ranges.js
+++ b/src/routes/isbn-registry/publisher-ranges.js
@@ -53,9 +53,6 @@ export default function (permissionMiddleware, identifierType) {
     .post('/:id/close', permissionMiddleware('ranges', 'update'), celebrate({
       [Segments.PARAMS]: validateRequestId
     }), close)
-    .get('/:id/get-publications', permissionMiddleware('publicationRequests', 'read'), celebrate({
-      [Segments.PARAMS]: validateRequestId
-    }), getPublications)
     .get('/:id', permissionMiddleware('ranges', 'read'), celebrate({
       [Segments.PARAMS]: validateRequestId
     }), read)
@@ -150,20 +147,6 @@ export default function (permissionMiddleware, identifierType) {
   async function close(req, res, next) {
     try {
       const result = await isbnSubRanges.close(req.params.id, req.user);
-
-      if (result) {
-        return res.status(HttpStatus.OK).json(result);
-      }
-
-      return res.status(HttpStatus.INTERNAL_SERVER_ERROR);
-    } catch (error) {
-      return next(error);
-    }
-  }
-
-  async function getPublications(req, res, next) {
-    try {
-      const result = await isbnSubRanges.getPublications(req.params.id);
 
       if (result) {
         return res.status(HttpStatus.OK).json(result);

--- a/src/routes/validations/message/index.js
+++ b/src/routes/validations/message/index.js
@@ -95,7 +95,6 @@ export const validateSendMessageIsbn = {
   langCode: Joi.string().regex(regexPatterns.langCode).required(),
   recipient: Joi.string().regex(regexPatterns.email).required(),
   subject: Joi.string().required(),
-  hasAttachment: Joi.boolean(),
   messageBody: Joi.string().required()
 };
 

--- a/src/routes/validations/publication/issn.js
+++ b/src/routes/validations/publication/issn.js
@@ -49,15 +49,15 @@ export const validateCreatePublicationIssn = {
     lastIssue: Joi.array().items(Joi.string().allow('').max(50)).max(5)
   }),
   mainSeries: Joi.object({
-    title: Joi.array().items(Joi.string().max(100)).max(6),
+    title: Joi.array().items(Joi.string().max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   subseries: Joi.object({
-    title: Joi.array().items(Joi.string().max(100)).max(6),
+    title: Joi.array().items(Joi.string().max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   anotherMedium: Joi.object({
-    title: Joi.array().items(Joi.string().max(100)).max(6),
+    title: Joi.array().items(Joi.string().max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   additionalInfo: Joi.string().max(2000)
@@ -84,15 +84,15 @@ export const validateUpdatePublicationIssn = {
     lastIssue: Joi.array().items(Joi.string().allow('').max(50)).max(5)
   }),
   mainSeries: Joi.object({
-    title: Joi.array().items(Joi.string().allow('').max(100)).max(6),
+    title: Joi.array().items(Joi.string().allow('').max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   subseries: Joi.object({
-    title: Joi.array().items(Joi.string().allow('').max(100)).max(6),
+    title: Joi.array().items(Joi.string().allow('').max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   anotherMedium: Joi.object({
-    title: Joi.array().items(Joi.string().allow('').max(100)).max(6),
+    title: Joi.array().items(Joi.string().allow('').max(100)).max(5),
     issn: Joi.array().items(Joi.string().allow('').regex(regexPatterns.issnNumber)).max(5)
   }),
   status: Joi.string().regex(regexPatterns.issnPublicationStatus),

--- a/test-fixtures/isbn-registry/messages/send/7/payload.json
+++ b/test-fixtures/isbn-registry/messages/send/7/payload.json
@@ -5,6 +5,5 @@
   "messageTemplateId": 1,
   "recipient": "example@example.com",
   "subject": "Esimerkkiotsikko",
-  "messageBody": "<p>Esimerkkiviesti</p>",
-  "hasAttachment": true
+  "messageBody": "<p>Esimerkkiviesti</p>"
 }

--- a/test-fixtures/issn-registry/requests/read/1/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/read/1/expectedPayload.json
@@ -14,34 +14,6 @@
   "publisherCreated": false,
   "langCode": "fi-FI",
   "status": "NOT_HANDLED",
-  "publicationIssn": [
-    {
-      "id": 1,
-      "title": "Foo title",
-      "subtitle": "Foo subtitle",
-      "issn": "",
-      "language": "FIN",
-      "medium": "PRINTED",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    },
-    {
-      "id": 2,
-      "title": "Bar Baz title",
-      "subtitle": null,
-      "issn": "",
-      "language": "FIN",
-      "medium": "ONLINE",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    }
-  ],
   "created": {},
   "createdBy": "system",
   "modified": {},

--- a/test-fixtures/issn-registry/requests/read/2/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/read/2/expectedPayload.json
@@ -14,34 +14,6 @@
   "publisherCreated": false,
   "langCode": "fi-FI",
   "status": "NOT_HANDLED",
-  "publicationIssn": [
-    {
-      "id": 1,
-      "title": "Foo title",
-      "subtitle": "Foo subtitle",
-      "issn": "",
-      "language": "FIN",
-      "medium": "PRINTED",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    },
-    {
-      "id": 2,
-      "title": "Bar Baz title",
-      "subtitle": null,
-      "issn": "",
-      "language": "FIN",
-      "medium": "ONLINE",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    }
-  ],
   "created": {},
   "createdBy": "system",
   "modified": {},

--- a/test-fixtures/issn-registry/requests/setPublisher/1/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/setPublisher/1/expectedPayload.json
@@ -14,34 +14,6 @@
   "publisherCreated": false,
   "langCode": "fi-FI",
   "status": "NOT_HANDLED",
-  "publicationIssn": [
-    {
-      "id": 1,
-      "title": "Foo title",
-      "subtitle": "Foo subtitle",
-      "issn": "",
-      "language": "FIN",
-      "medium": "PRINTED",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    },
-    {
-      "id": 2,
-      "title": "Bar Baz title",
-      "subtitle": null,
-      "issn": "",
-      "language": "FIN",
-      "medium": "ONLINE",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "system"
-    }
-  ],
   "created": {},
   "createdBy": "system",
   "modified": {},

--- a/test-fixtures/issn-registry/requests/setPublisher/2/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/setPublisher/2/expectedPayload.json
@@ -14,34 +14,6 @@
   "publisherCreated": false,
   "langCode": "fi-FI",
   "status": "NOT_HANDLED",
-  "publicationIssn": [
-    {
-      "id": 1,
-      "title": "Foo title",
-      "subtitle": "Foo subtitle",
-      "issn": "",
-      "language": "FIN",
-      "medium": "PRINTED",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "admin"
-    },
-    {
-      "id": 2,
-      "title": "Bar Baz title",
-      "subtitle": null,
-      "issn": "",
-      "language": "FIN",
-      "medium": "ONLINE",
-      "status": "NO_PREPUBLICATION_RECORD",
-      "created": {},
-      "createdBy": "system",
-      "modified": {},
-      "modifiedBy": "admin"
-    }
-  ],
   "created": {},
   "createdBy": "system",
   "modified": {},

--- a/test-fixtures/issn-registry/requests/update/1/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/update/1/expectedPayload.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "publisherId": null,
+  "publisherName": null,
   "publisher": "Foo Publisher Edit",
   "contactPerson": "Foo Bar Edit",
   "email": "example.edit@example.com",

--- a/test-fixtures/issn-registry/requests/update/2/expectedPayload.json
+++ b/test-fixtures/issn-registry/requests/update/2/expectedPayload.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "publisherId": null,
+  "publisherName": null,
   "publisher": "Foo Publisher Edit",
   "contactPerson": "Foo Bar Edit",
   "email": "example.edit@example.com",


### PR DESCRIPTION
- Made number of associated items in issn-registry request consistent (5)
- Removed hasAttachment parameter from list of approved parameters for isbn-registry messages send endpoint since it is not utilized by the system
- Removed getPublications route in isbn-registry publisher-ranges router as the logic is not used/implemented
- Removed associated publication information from issn-registry request read result
- Changed issn-registry request update result to return read endpoint so that frontend state is kept consistent