### PR TITLE
Multiple minor fixes

### DIFF
--- a/apidoc/openapi.yaml
+++ b/apidoc/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: 2.2.0
+  version: 2.3.0
   title: Identifier Services API
   contact:
     name: Identifier Services support

--- a/apidoc/schemas/responses/IsbnIsmnPublicationRequestList.yaml
+++ b/apidoc/schemas/responses/IsbnIsmnPublicationRequestList.yaml
@@ -19,3 +19,5 @@ properties:
           type: string
         comments:
           type: string
+        created:
+          type: string

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "GPL-3.0-only",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "./dist/index.js",
   "engines": {
     "node": ">=18"

--- a/src/interfaces/isbn-registry/requests/publication.js
+++ b/src/interfaces/isbn-registry/requests/publication.js
@@ -154,12 +154,14 @@ export default function () {
    * @returns Publication request as object
    */
   async function read(id) {
-    const result = await publicationModel.findByPk(id, {include: [
-      {
-        association: 'publisher',
-        attributes: ['id', 'officialName']
-      }
-    ]});
+    const result = await publicationModel.findByPk(id, {
+      include: [
+        {
+          association: 'publisher',
+          attributes: ['id', 'officialName']
+        }
+      ]
+    });
 
     // Include identifierBatch information to response so that loadTemplate functionality may be utilized
     const identifierBatches = await identifierBatchModel.findAll({where: {publicationId: id}});
@@ -294,7 +296,7 @@ export default function () {
    * @returns Object containing results if succeeds, otherwise throws ApiError
    */
   async function query(guiOpts) {
-    const attributes = ['id', 'title', 'officialName', 'langCode', 'publicationType', 'comments'];
+    const attributes = ['id', 'title', 'officialName', 'langCode', 'publicationType', 'comments', 'created'];
     const {offset, limit, searchText, state} = guiOpts;
     const order = [['id', 'DESC']];
     const trimmedSearchText = searchText ? searchText.trim() : undefined;

--- a/src/interfaces/isbn-registry/requests/publisher.js
+++ b/src/interfaces/isbn-registry/requests/publisher.js
@@ -305,7 +305,7 @@ export default function () {
       'additionalInfo'
     ];
 
-    const attributes = ['id', 'officialName', 'email', 'langCode', 'created', 'additionalInfo'];
+    const attributes = ['id', 'officialName', 'email', 'langCode', 'created', 'additionalInfo', 'created'];
     const {searchText, limit, offset} = guiOpts;
     const order = [['id', 'DESC']];
 
@@ -316,10 +316,12 @@ export default function () {
       where: {
         [Op.and]: [
           {...conditions},
-          {[Op.and]: [
-            {'$isbnSubRanges.id$': null},
-            {'$ismnSubRanges.id$': null}
-          ]}
+          {
+            [Op.and]: [
+              {'$isbnSubRanges.id$': null},
+              {'$ismnSubRanges.id$': null}
+            ]
+          }
         ]
       },
       include: [

--- a/src/interfaces/isbn-registry/requests/publisher.js
+++ b/src/interfaces/isbn-registry/requests/publisher.js
@@ -305,7 +305,7 @@ export default function () {
       'additionalInfo'
     ];
 
-    const attributes = ['id', 'officialName', 'email', 'langCode', 'created', 'additionalInfo', 'created'];
+    const attributes = ['id', 'officialName', 'email', 'langCode', 'created', 'additionalInfo'];
     const {searchText, limit, offset} = guiOpts;
     const order = [['id', 'DESC']];
 

--- a/src/interfaces/issn-registry/marc.js
+++ b/src/interfaces/issn-registry/marc.js
@@ -223,14 +223,8 @@ function generate245({publication}) {
     return [];
   }
 
-  let subfieldAValue = publication.title;
+  const subfieldAValue = publication.subtitle ? `${publication.title}.` : `${publication.title} :`;
   const subfieldBValue = publication.subtitle ? `${publication.subtitle}.` : undefined;
-
-  if (!publication.subtitle) {
-    subfieldAValue += '.';
-  } else if (publication.subtitle) {
-    subfieldAValue += ' :';
-  }
 
   return {
     tag: '245', ind1: '0', ind2: '0',

--- a/src/interfaces/issn-registry/marc.js
+++ b/src/interfaces/issn-registry/marc.js
@@ -204,7 +204,9 @@ function generate042() {
 }
 
 function generate222({publication, electronical}) {
-  if (!publication.title) {
+  const anotherMedium = getTitleAndIssnFromJson(publication.anotherMedium);
+
+  if (!publication.title || anotherMedium.length === 0) {
     return [];
   }
 
@@ -462,21 +464,23 @@ function getTitleAndIssnFromJson(v) {
   }
 
   // Return array of values that can be gathered through looping the paired properties
-  return [...Array(v.title.length).keys()].map(idx => {
-    const result = {};
+  return [...Array(v.title.length).keys()]
+    .map(idx => {
+      const result = {};
 
-    /* eslint-disable functional/immutable-data,functional/no-conditional-statements */
-    if (v.title.length - 1 >= idx) {
-      result.title = v.title[idx];
-    }
+      /* eslint-disable functional/immutable-data,functional/no-conditional-statements */
+      if (v.title.length - 1 >= idx) {
+        result.title = v.title[idx];
+      }
 
-    if (v.issn.length - 1 >= idx) {
-      result.issn = v.issn[idx];
-    }
-    /* eslint-enable functional/immutable-data,functional/no-conditional-statements */
+      if (v.issn.length - 1 >= idx) {
+        result.issn = v.issn[idx];
+      }
+      /* eslint-enable functional/immutable-data,functional/no-conditional-statements */
 
-    return Object.keys.length > 0 ? result : undefined;
-  });
+      return Object.keys(result).length > 0 ? result : undefined;
+    })
+    .filter(v => v !== undefined);
 }
 
 function generateLOW() {

--- a/src/interfaces/issn-registry/marc.js
+++ b/src/interfaces/issn-registry/marc.js
@@ -217,26 +217,25 @@ function generate222({publication, electronical}) {
   return {tag: '222', ind1: ' ', ind2: '0', subfields: [{code: 'a', value: publication.title}, subfieldB]};
 }
 
-function generate245({publication, publisher}) {
+function generate245({publication}) {
   /* eslint-disable functional/no-let,functional/no-conditional-statements,no-nested-ternary */
   if (!publication.title) {
     return [];
   }
 
   let subfieldAValue = publication.title;
-  const subfieldBValue = publication.subtitle ? publisher.officialName ? `${publication.subtitle} /` : `${publication.subtitle}.` : undefined;
-  const subfieldCValue = publisher.officialName ? `${publisher.officialName}.` : undefined;
+  const subfieldBValue = publication.subtitle ? `${publication.subtitle}.` : undefined;
 
-  if (!publication.subtitle && !publisher.officialName) {
+  if (!publication.subtitle) {
     subfieldAValue += '.';
   } else if (publication.subtitle) {
     subfieldAValue += ' :';
-  } else if (publisher.officialName) {
-    subfieldAValue += ' /';
   }
 
-  return {tag: '245', ind1: '0', ind2: '0',
-    subfields: [{code: 'a', value: subfieldAValue}, {code: 'b', value: subfieldBValue}, {code: 'c', value: subfieldCValue}].filter(v => v.value)};
+  return {
+    tag: '245', ind1: '0', ind2: '0',
+    subfields: [{code: 'a', value: subfieldAValue}, {code: 'b', value: subfieldBValue}].filter(v => v.value)
+  };
   /* eslint-enable functional/no-let,functional/no-conditional-statements,no-nested-ternary */
 }
 
@@ -417,8 +416,10 @@ function generate776({publication, electronical}) {
       return {tag: '776', ind1: '0', ind2: '8', subfields: [{code: 'i', value: subfieldI}, {code: 't', value: series.title}, {code: '9', value: 'FENNI<KEEP>'}]};
     }
 
-    return {tag: '776', ind1: '0', ind2: '8',
-      subfields: [{code: 'i', value: subfieldI}, {code: 't', value: series.title}, {code: 'x', value: series.issn}, {code: '9', value: 'FENNI<KEEP>'}]};
+    return {
+      tag: '776', ind1: '0', ind2: '8',
+      subfields: [{code: 'i', value: subfieldI}, {code: 't', value: series.title}, {code: 'x', value: series.issn}, {code: '9', value: 'FENNI<KEEP>'}]
+    };
   }
 }
 
@@ -437,8 +438,10 @@ function generate780({publication}) {
       return {tag: '780', ind1: '0', ind2: '0', subfields: [{code: 't', value: series.title}, {code: '9', value: 'FENNI<KEEP>'}]};
     }
 
-    return {tag: '780', ind1: '0', ind2: '0',
-      subfields: [{code: 't', value: series.title}, {code: 'x', value: series.issn}, {code: '9', value: 'FENNI<KEEP>'}]};
+    return {
+      tag: '780', ind1: '0', ind2: '0',
+      subfields: [{code: 't', value: series.title}, {code: 'x', value: series.issn}, {code: '9', value: 'FENNI<KEEP>'}]
+    };
   }
 }
 

--- a/test-fixtures/isbn-registry/requests/publications/query/1/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/1/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Test book",
-      "comments": ""
+      "comments": "",
+      "created": {}
     },
     {
       "id": 1,
@@ -15,7 +16,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/2/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/2/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Test book",
-      "comments": ""
+      "comments": "",
+      "created": {}
     },
     {
       "id": 1,
@@ -15,7 +16,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/5/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/5/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Test book",
-      "comments": ""
+      "comments": "",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/6/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/6/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Test book",
-      "comments": ""
+      "comments": "",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/7/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/7/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/8/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/8/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Test book",
-      "comments": ""
+      "comments": "",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/9/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/9/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/a10/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/a10/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/a11/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/a11/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/a12/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/a12/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }

--- a/test-fixtures/isbn-registry/requests/publications/query/a13/expectedPayload.json
+++ b/test-fixtures/isbn-registry/requests/publications/query/a13/expectedPayload.json
@@ -7,7 +7,8 @@
       "langCode": "fi-FI",
       "publicationType": "BOOK",
       "title": "Foo Book",
-      "comments": "Esimerkki käsittelytiedosta"
+      "comments": "Esimerkki käsittelytiedosta",
+      "created": {}
     }
   ]
 }


### PR DESCRIPTION
- Remove subfield f245 $c from ISSN-marc generation. f245 is also no longer dependent on publisher information
- ISSN marc f222 is no longer generated if no anotherMedium information can be found
- Add created-attribute to isbn-registry request queries so that it can be displayed in list view of requests in Admin UI
- Update version number of API to 2.3.0