### PR TITLE
Fix publisher identifier cancellation bug and extend logging 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3877,9 +3877,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001605",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
-      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/interfaces/isbn-registry/ranges/publisherRanges.js
+++ b/src/interfaces/isbn-registry/ranges/publisherRanges.js
@@ -432,7 +432,7 @@ export default function (identifierType) {
 
       if (subrange.canceled > 0) {
         // Delete canceled identifiers that need to be deleted
-        const canceledIdentifierDestroyResult = await subRangeCanceledModel.destroy({
+        const canceledIdentifierDestroyResult = await identifierCanceledModel.destroy({
           where: {
             identifierType: IDENTIFIER_TYPE,
             subRangeId: subrange.id
@@ -440,6 +440,7 @@ export default function (identifierType) {
           transaction: t
         });
 
+        // Confirm that the result was as expected
         if (canceledIdentifierDestroyResult !== subrange.canceled) {
           throw new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, 'Error in removing canceled identifiers during subrange removal');
         }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -62,7 +62,7 @@ if (NODE_ENV === 'test') {
 } else {
   const applyEngineDefinitions = isMysqlOrMaria(DB_DIALECT);
 
-  logger.info(`using DB dialect of ${DB_DIALECT}`);
+  logger.info(`using DB dialect of "${DB_DIALECT}"`);
   logger.info(`apply DB engine definitions regarding engine, charset and collate: ${applyEngineDefinitions}`);
 
   sequelize = new Sequelize(DB_URI, {

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -63,7 +63,7 @@ if (NODE_ENV === 'test') {
   const applyEngineDefinitions = isMysqlOrMaria(DB_DIALECT);
 
   logger.info(`using DB dialect of ${DB_DIALECT}`);
-  logger.info('apply DB engine definitions regarding engine, charset and collate: ', applyEngineDefinitions);
+  logger.info(`apply DB engine definitions regarding engine, charset and collate: ${applyEngineDefinitions}`);
 
   sequelize = new Sequelize(DB_URI, {
     dialect: DB_DIALECT,

--- a/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/dbContents.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/dbContents.json
@@ -1,0 +1,170 @@
+{
+  "isbnRange": [
+    {
+      "id": 2,
+      "prefix": 978,
+      "langGroup": 951,
+      "category": 4,
+      "rangeBegin": "8900",
+      "rangeEnd": "9499",
+      "free": 598,
+      "taken": 2,
+      "canceled": 0,
+      "next": "8902",
+      "isActive": 1,
+      "isClosed": 0,
+      "idOld": null,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "publisherIsbn": [
+    {
+      "id": 2,
+      "officialName": "XYZ Publisher Request",
+      "otherNames": "",
+      "address": "XYZ 123",
+      "zip": "00000",
+      "city": "Foobarila",
+      "phone": "98765432",
+      "email": "xyz@example.com",
+      "www": "",
+      "langCode": "en-GB",
+      "contactPerson": "Baz Baz",
+      "additionalInfo": "",
+      "hasQuitted": 0,
+      "yearQuitted": "",
+      "activeIdentifierIsbn": "978-951-8900",
+      "activeIdentifierIsmn": "",
+      "frequencyCurrent": "2",
+      "frequencyNext": "2",
+      "affiliates": "",
+      "distributors": "",
+      "classification": ["100"],
+      "classificationOther": "",
+      "confirmation": "",
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "isbnSubRange": [
+    {
+      "id": 2,
+      "publisherIdentifier": "978-951-8900",
+      "isbnRangeId": 2,
+      "publisherId": 2,
+      "category": 2,
+      "rangeBegin": "00",
+      "rangeEnd": "99",
+      "free": 96,
+      "taken": 4,
+      "canceled": 4,
+      "deleted": 0,
+      "next": "04",
+      "isActive": 1,
+      "isClosed": 0,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    },
+    {
+      "id": 3,
+      "publisherIdentifier": "978-951-8901",
+      "isbnRangeId": 2,
+      "publisherId": 2,
+      "category": 2,
+      "rangeBegin": "00",
+      "rangeEnd": "99",
+      "free": 96,
+      "taken": 4,
+      "canceled": 4,
+      "deleted": 0,
+      "next": "04",
+      "isActive": 0,
+      "isClosed": 0,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "identifierCanceled": [
+    {
+      "id": 1,
+      "category": 2,
+      "identifier": "978-951-8900-00-2",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 2,
+      "category": 2,
+      "identifier": "978-951-8900-01-9",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 3,
+      "category": 2,
+      "identifier": "978-951-8900-02-6",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 4,
+      "category": 2,
+      "identifier": "978-951-8900-03-3",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 5,
+      "category": 2,
+      "identifier": "978-951-8901-00-9",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 6,
+      "category": 2,
+      "identifier": "978-951-8901-01-6",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 7,
+      "category": 2,
+      "identifier": "978-951-8901-02-3",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 8,
+      "category": 2,
+      "identifier": "978-951-8901-03-0",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    }
+  ]
+}

--- a/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/dbExpected.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/dbExpected.json
@@ -1,0 +1,135 @@
+{
+  "isbnRange": [
+    {
+      "id": 2,
+      "prefix": 978,
+      "langGroup": 951,
+      "category": 4,
+      "rangeBegin": "8900",
+      "rangeEnd": "9499",
+      "free": 598,
+      "taken": 2,
+      "canceled": 1,
+      "next": "8902",
+      "isActive": 1,
+      "isClosed": 0,
+      "idOld": null,
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "publisherIsbn": [
+    {
+      "id": 2,
+      "officialName": "XYZ Publisher Request",
+      "otherNames": "",
+      "previousNames": null,
+      "address": "XYZ 123",
+      "addressLine1": null,
+      "zip": "00000",
+      "city": "Foobarila",
+      "phone": "98765432",
+      "email": "xyz@example.com",
+      "www": "",
+      "langCode": "en-GB",
+      "contactPerson": "Baz Baz",
+      "additionalInfo": "",
+      "hasQuitted": 0,
+      "yearQuitted": "",
+      "activeIdentifierIsbn": "",
+      "activeIdentifierIsmn": "",
+      "frequencyCurrent": "2",
+      "frequencyNext": "2",
+      "affiliateOf": null,
+      "affiliates": "",
+      "distributorOf": null,
+      "distributors": "",
+      "classification": "100",
+      "classificationOther": "",
+      "confirmation": "",
+      "promoteSorting": 0,
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "isbnSubRange": [
+    {
+      "id": 3,
+      "idOld": null,
+      "publisherIdentifier": "978-951-8901",
+      "isbnRangeId": 2,
+      "publisherId": 2,
+      "category": 2,
+      "rangeBegin": "00",
+      "rangeEnd": "99",
+      "free": 96,
+      "taken": 4,
+      "canceled": 4,
+      "deleted": 0,
+      "next": "04",
+      "isActive": 0,
+      "isClosed": 0,
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "isbnSubRangeCanceled": [
+    {
+      "id": 1,
+      "idOld": null,
+      "rangeId": 2,
+      "identifier": "978-951-8900",
+      "category": 4,
+      "canceled": {},
+      "canceledBy": "system"
+    }
+  ],
+  "identifierCanceled": [
+    {
+      "id": 5,
+      "category": 2,
+      "identifier": "978-951-8901-00-9",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 6,
+      "category": 2,
+      "identifier": "978-951-8901-01-6",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 7,
+      "category": 2,
+      "identifier": "978-951-8901-02-3",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 8,
+      "category": 2,
+      "identifier": "978-951-8901-03-0",
+      "identifierType": "ISBN",
+      "publisherId": 2,
+      "subRangeId": 3,
+      "canceled": {},
+      "canceledBy": "system"
+    }
+  ]
+}

--- a/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/metadata.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/isbn/remove/9/metadata.json
@@ -1,0 +1,8 @@
+{
+  "descr": "Correctly manages deletion of canceled identifiers when ISBN subrange has been given identifiers from, but they all have been canceled thus allowing subrange deletion",
+  "requestUrl": "/isbn-registry/publisher-ranges/isbn/2",
+  "username": "system",
+  "password": "system",
+  "method": "delete",
+  "expectedStatus": 204
+}

--- a/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/dbContents.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/dbContents.json
@@ -1,0 +1,131 @@
+{
+  "ismnRange": [
+    {
+      "id": 1,
+      "prefix": "979-0",
+      "category": 5,
+      "rangeBegin": "55001",
+      "rangeEnd": "55025",
+      "free": 23,
+      "taken": 2,
+      "canceled": 0,
+      "next": "55003",
+      "isActive": 1,
+      "isClosed": 0,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "publisherIsbn": [
+    {
+      "id": 1,
+      "officialName": "FooBar Publisher",
+      "otherNames": "OtherFooBar, OtherAnotherFooBar",
+      "previousNames": ["PriorFoo", "AnotherPriorFoo"],
+      "address": "FooBar 123",
+      "zip": "00000",
+      "city": "Foobarila",
+      "phone": "1234567",
+      "email": "foo.bar@example.com",
+      "www": "http://example.com",
+      "langCode": "fi-FI",
+      "contactPerson": "Foo Bar",
+      "additionalInfo": "",
+      "hasQuitted": 0,
+      "yearQuitted": "",
+      "activeIdentifierIsbn": "",
+      "activeIdentifierIsmn": "979-0-55002",
+      "frequencyCurrent": "1",
+      "frequencyNext": "1",
+      "affiliates": "FooBar Suomi\nBazBar 123\n00000 Foobarila",
+      "distributors": "Foo Jakelu\nBazBar 123\n00000 Foobarila",
+      "classification": ["40", "100"],
+      "classificationOther": "",
+      "confirmation": "",
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "ismnSubRange": [
+    {
+      "id": 1,
+      "idOld": null,
+      "publisherIdentifier": "979-0-55001",
+      "publisherId": 1,
+      "ismnRangeId": 1,
+      "category": 3,
+      "rangeBegin": "000",
+      "rangeEnd": "999",
+      "free": 998,
+      "taken": 2,
+      "canceled": 2,
+      "deleted": 0,
+      "next": "002",
+      "isActive": 0,
+      "isClosed": 0,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    },
+    {
+      "id": 2,
+      "idOld": null,
+      "publisherIdentifier": "979-0-55002",
+      "publisherId": 1,
+      "ismnRangeId": 1,
+      "category": 3,
+      "rangeBegin": "000",
+      "rangeEnd": "999",
+      "free": 998,
+      "taken": 2,
+      "canceled": 2,
+      "deleted": 0,
+      "next": "002",
+      "isActive": 1,
+      "isClosed": 0,
+      "createdBy": "system",
+      "modifiedBy": "system"
+    }
+  ],
+  "identifierCanceled": [
+    {
+      "id": 1,
+      "category": 3,
+      "identifier": "979-0-55001-000-0",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 1,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 2,
+      "category": 3,
+      "identifier": "979-0-55001-001-7",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 1,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 3,
+      "category": 3,
+      "identifier": "979-0-55002-000-9",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 4,
+      "category": 3,
+      "identifier": "979-0-55002-001-6",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 2,
+      "canceled": {},
+      "canceledBy": "system"
+    }
+  ]
+}

--- a/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/dbExpected.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/dbExpected.json
@@ -1,0 +1,103 @@
+{
+  "ismnRange": [
+    {
+      "id": 1,
+      "prefix": "979-0",
+      "category": 5,
+      "rangeBegin": "55001",
+      "rangeEnd": "55025",
+      "free": 24,
+      "taken": 1,
+      "canceled": 0,
+      "next": "55002",
+      "isActive": 1,
+      "isClosed": 0,
+      "idOld": null,
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "publisherIsbn": [
+    {
+      "id": 1,
+      "officialName": "FooBar Publisher",
+      "otherNames": "OtherFooBar, OtherAnotherFooBar",
+      "previousNames": "{\"name\":[\"PriorFoo\",\"AnotherPriorFoo\"]}",
+      "address": "FooBar 123",
+      "addressLine1": null,
+      "zip": "00000",
+      "city": "Foobarila",
+      "phone": "1234567",
+      "email": "foo.bar@example.com",
+      "www": "http://example.com",
+      "langCode": "fi-FI",
+      "contactPerson": "Foo Bar",
+      "additionalInfo": "",
+      "hasQuitted": 0,
+      "yearQuitted": "",
+      "activeIdentifierIsbn": "",
+      "activeIdentifierIsmn": "",
+      "frequencyCurrent": "1",
+      "frequencyNext": "1",
+      "affiliateOf": null,
+      "affiliates": "FooBar Suomi\nBazBar 123\n00000 Foobarila",
+      "distributorOf": null,
+      "distributors": "Foo Jakelu\nBazBar 123\n00000 Foobarila",
+      "classification": "40,100",
+      "classificationOther": "",
+      "promoteSorting": 0,
+      "confirmation": "",
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "ismnSubRange": [
+    {
+      "id": 1,
+      "idOld": null,
+      "publisherIdentifier": "979-0-55001",
+      "publisherId": 1,
+      "ismnRangeId": 1,
+      "category": 3,
+      "rangeBegin": "000",
+      "rangeEnd": "999",
+      "free": 998,
+      "taken": 2,
+      "canceled": 2,
+      "deleted": 0,
+      "next": "002",
+      "isActive": 0,
+      "isClosed": 0,
+      "created": {},
+      "createdBy": "system",
+      "modified": {},
+      "modifiedBy": "system"
+    }
+  ],
+  "identifierCanceled": [
+    {
+      "id": 1,
+      "category": 3,
+      "identifier": "979-0-55001-000-0",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 1,
+      "canceled": {},
+      "canceledBy": "system"
+    },
+    {
+      "id": 2,
+      "category": 3,
+      "identifier": "979-0-55001-001-7",
+      "identifierType": "ISMN",
+      "publisherId": 1,
+      "subRangeId": 1,
+      "canceled": {},
+      "canceledBy": "system"
+    }
+  ]
+}

--- a/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/metadata.json
+++ b/test-fixtures/isbn-registry/publisher-ranges/ismn/remove/9/metadata.json
@@ -1,0 +1,8 @@
+{
+  "descr": "Correctly manages deletion of canceled identifiers when ISMN subrange has been given identifiers from, but they all have been canceled thus allowing subrange deletion",
+  "requestUrl": "/isbn-registry/publisher-ranges/ismn/2",
+  "username": "system",
+  "password": "system",
+  "method": "delete",
+  "expectedStatus": 204
+}


### PR DESCRIPTION
- Fixes bug which prevents canceling publisher identifier in case where publisher identifier contains only canceled identifiers
- Adds logging to DB configuration used in runtime